### PR TITLE
pull-events-stats: Add script for analyzing image pull performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,65 @@ SPDX-License-Identifier: Apache-2.0
 
 Ramen is an [open-cluster-management (OCM)](https://open-cluster-management.io/concepts/architecture/)
 [placement](https://open-cluster-management.io/concepts/placement/) extension
-that provides recovery and relocation services for
-[workloads](https://kubernetes.io/docs/concepts/workloads/), and their
-persistent data, across a set of OCM managed clusters. Ramen provides
+that provides **OpenShift-native Disaster Recovery** capabilities for
+[workloads](https://kubernetes.io/docs/concepts/workloads/) and their
+persistent data across a set of OCM managed clusters. Ramen provides
 cloud-native interfaces to orchestrate the placement of workloads and their
 data on PersistentVolumes, which include:
 
-- Relocating workloads to a peer cluster, for planned migrations across clusters
-- Recovering workloads to a peer cluster, due to unplanned loss of a cluster
+- **Relocate**: Planned migration of workloads to a
+  peer cluster for maintenance or optimization
+- **Failover**: Unplanned recovery of workloads to
+  a peer cluster due to cluster loss or failure
+- **Failback**: Restoring workloads to the
+  original cluster after recovery from a disaster
 
 Ramen relies on storage plugins providing support for the CSI
 [storage replication addon](https://github.com/csi-addons/volume-replication-operator),
 of which [ceph-csi](https://github.com/ceph/ceph-csi/) is a sample implementation.
+
+## Workload Protection Methods
+
+Ramen supports multiple approaches to protect and replicate applications across clusters:
+
+### GitOps-based Protection (Recommended)
+
+Applications deployed via **GitOps** (e.g., ArgoCD ApplicationSets)
+are automatically protected by replicating their Git-based configuration.
+This is the most common deployment pattern for
+cloud-native applications.
+
+### Discovered Applications
+
+Ramen can discover and protect existing applications deployed
+through traditional methods (e.g., kubectl, Helm).
+The system automatically identifies application resources
+and their persistent volumes for protection.
+
+### Recipe-based Protection
+
+[Recipes](https://github.com/ramendr/recipe) provide
+vendor-supplied disaster recovery
+specifications for complex stateful
+applications. Recipes define:
+
+- Application-specific capture workflows (e.g., database quiesce operations)
+- Recovery workflows with proper sequencing
+- Custom hooks for pre/post DR operations
+
+**Target Audience:**
+
+- **Software Vendors**: Create recipes to
+  accompany their products, ensuring proper
+  DR protection out-of-the-box
+- **Advanced Users**: Write custom
+  recipes when vendors haven't provided
+  them for specific applications
+
+Recipes complement volume replication by
+capturing application-specific state and
+metadata that goes beyond simple PVC
+snapshots.
 
 For details regarding use-cases for Ramen see the [motivation](docs/motivation.md)
 guide.

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,120 +3,494 @@ SPDX-FileCopyrightText: The RamenDR authors
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Install
+# Installing Ramen
+
+This guide describes how to install Ramen's disaster recovery operators on your
+cluster environment.
+
+## Overview
+
+Ramen consists of two operators that work together to provide disaster recovery
+capabilities:
+
+1. **Ramen Hub Operator** - Installed on the OCM hub cluster, orchestrates DR
+   operations across managed clusters
+1. **Ramen DR Cluster Operator** - Installed on each OCM managed cluster,
+   manages local volume replication and workload protection
 
 ## Prerequisites
 
-### OCM managed multi-cluster setup
+Before installing Ramen, ensure the following requirements are met:
 
-Ramen works as part of the [OCM hub](https://open-cluster-management.io/concepts/architecture/#hub-cluster)
-cluster to orchestrate the [placement](https://open-cluster-management.io/concepts/placement/)
-of [workloads](https://kubernetes.io/docs/concepts/workloads/) and their attachment
-to PersistentVolumes, on [OCM managed clusters](https://open-cluster-management.io/concepts/managedcluster/).
+### 1. Open Cluster Management (OCM) Setup
 
-[Ramen hub](#ramen-hub-operator) and [Ramen cluster](#ramen-cluster-operator)
-operators hence require an OCM managed multi-cluster setup for their
-operation.
+Ramen requires an [OCM hub cluster](https://open-cluster-management.io/concepts/architecture/#hub-cluster)
+with at least two [managed clusters](https://open-cluster-management.io/concepts/managedcluster/)
+for disaster recovery operations.
 
-### OCM Managed Cluster supporting VolumeReplication CRD
+**Requirements:**
 
-Ramen works as part of the [OCM managed clusters](https://open-cluster-management.io/concepts/managedcluster/)
-to orchestrate:
+- OCM hub cluster with `multicluster-engine` or
+  `advanced-cluster-management` installed
+- At least 2 managed clusters registered with the hub
+- Clusters must be able to communicate for replication (directly or via
+  Submariner)
 
-- [VolumeReplication](https://github.com/csi-addons/volume-replication-operator/blob/main/api/v1alpha1/volumereplication_types.go)
-  resources for all PVCs of a workload
-- Preserving relevant cluster data regarding each PVC that is replicated
+**Verify OCM setup:**
 
-VolumeReplication custom resources require storage providers to support
-[CSI extensions](https://github.com/csi-addons/spec) that enable managing
-replication features for provisioned volumes.
-[Ceph-CSI](https://github.com/ceph/ceph-csi/) is one such storage provider
-that supports the required extensions.
+```bash
+# On the hub cluster
+kubectl get managedclusters
+```
 
-[Ramen cluster operator](#ramen-cluster-operator) hence should be deployed
-to OCM managed clusters that support VolumeReplication extensions.
+You should see at least two managed clusters in `Ready` state.
 
-### S3 store
+### 2. Storage Replication Support
 
-Ramen preserves cluster data related to PVC resources in an S3 compatible
-object store. An S3 store endpoint is hence required as part of the setup.
+Each managed cluster must have storage that supports volume replication through
+one of these methods:
 
-**NOTE**: Ramen specifically stores PV cluster data for a replicated PVC, to
-restore the same across peer cluster prior to deploying the PVCs of the
-workload, this ensures proper binding of the PVC resources to the replicated
-storage end points.
+#### Option A: Async Replication (VolumeReplication)
 
-### Operator lifecycle manager (OLM)
+Storage must support the CSI
+[VolumeReplication](https://github.com/csi-addons/volume-replication-operator)
+extensions.
 
-Ramen components are provided as [OLM](https://olm.operatorframework.io/docs/getting-started/)
-catalog sources in the [Ramen catalog](https://quay.io/repository/ramendr/ramen-operator-catalog?tab=info).
+**Supported storage providers:**
 
-All clusters that require Ramen hub or cluster components installed, require
-OLM installed on the same.
+- [Ceph-CSI](https://github.com/ceph/ceph-csi/) with RBD mirroring
+- Other CSI drivers implementing the VolumeReplication spec
 
-### Kubernetes versions
+**Requirements:**
 
-Kubernetes versions supported are [1.20](https://kubernetes.io/releases/)
-or higher.
+- VolumeReplication CRD installed on managed clusters
+- VolumeReplicationClass configured for your storage
+- Storage replication configured between peer clusters (e.g., Ceph RBD
+  mirroring)
 
-### Tool versions
+**Verify VolumeReplication support:**
 
-Installation and deployment require the following tools at specified versions
-(or higher):
+```bash
+# On each managed cluster
+kubectl get crd volumereplicationclasses.replication.storage.openshift.io
+kubectl get volumereplicationclass
+```
 
-- kubectl > v1.21
-    - kubectl version can be verfied using
+#### Option B: Sync Replication (VolSync)
 
-      ```bash
-      kubectl version
-      ```
+Storage must support CSI snapshots for VolSync-based replication.
 
-## Ramen hub operator
+**Requirements:**
 
-`ramen-hub-operator` is the controller for managing the life cycle of user
-created [DRPlacementControl (DRPC)](drpc-crd.md) Ramen API resources and
-administrator created [DRPolicy](drpolicy-crd.md) Ramen API resources, and is
-installed on the **OCM hub cluster**.
+- VolSync operator installed on managed clusters
+- VolumeSnapshotClass configured
+- CSI driver supporting snapshots
 
-### Install ramen-hub-operator
+**Verify VolSync support:**
 
-To install `ramen-hub-operator` configure [kubectl](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#context)
-to use the desired OCM hub cluster and execute:
+```bash
+# On each managed cluster
+kubectl get csv -n openshift-operators | grep volsync
+kubectl get volumesnapshotclass
+```
+
+### 3. S3 Object Storage
+
+Ramen stores cluster metadata (PV specs, VRG state) in S3-compatible object
+storage for cross-cluster recovery.
+
+**Requirements:**
+
+- S3-compatible object store accessible from all managed clusters
+- Bucket(s) created for each managed cluster
+- S3 credentials (access key and secret key)
+
+**Supported S3 providers:**
+
+- AWS S3
+- Ceph RGW (RADOS Gateway)
+- MinIO
+- Any other S3-compatible storage
+
+**S3 access will be configured after installation** - see
+[configure.md](configure.md).
+
+### 4. Operator Lifecycle Manager (OLM)
+
+Ramen operators are distributed via OLM catalogs.
+
+**Requirements:**
+
+- OLM installed on hub and managed clusters
+- OpenShift 4.x includes OLM by default
+- For vanilla Kubernetes, [install
+  OLM](https://olm.operatorframework.io/docs/getting-started/)
+
+**Verify OLM:**
+
+```bash
+kubectl get csv -n openshift-operators  # or other namespace
+```
+
+### 5. Kubernetes/OpenShift Versions
+
+**Supported versions:**
+
+- Kubernetes 1.20 or higher
+- OpenShift 4.10 or higher (recommended for full feature support)
+
+**Verify cluster version:**
+
+```bash
+kubectl version --short
+```
+
+### 6. Required Tools
+
+The following tools must be installed on your workstation:
+
+- **kubectl** >= v1.21 - Kubernetes CLI
+
+  ```bash
+  kubectl version --client
+  ```
+
+- **oc** (optional) - OpenShift CLI, if using OpenShift
+
+  ```bash
+  oc version --client
+  ```
+
+### 7. Optional Components
+
+These components enhance Ramen's capabilities:
+
+#### Velero (for Kube Object Protection)
+
+Required if protecting applications using discovered application or Recipe
+methods.
+
+**Install on each managed cluster:**
+
+```bash
+# Example using Helm
+helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts
+helm install velero vmware-tanzu/velero --namespace velero --create-namespace \
+  --set configuration.backupStorageLocation[0].bucket=<your-bucket> \
+  --set configuration.backupStorageLocation[0].config.region=<region> \
+  --set-file credentials.secretContents.cloud=<path-to-credentials>
+```
+
+**Verify:**
+
+```bash
+kubectl get deploy -n velero
+```
+
+#### Recipe CRD (for Recipe-based Protection)
+
+Required if using Recipe-based workload protection.
+
+The Recipe CRD is available at:
+[recipe/config/crd/bases/ramendr.openshift.io_recipes.yaml](https://github.com/RamenDR/recipe/blob/main/config/crd/bases/ramendr.openshift.io_recipes.yaml)
+
+Installation instructions are in [recipe.md](recipe.md).
+
+## Installation Steps
+
+### Step 1: Install Ramen Hub Operator
+
+The `ramen-hub-operator` manages disaster recovery orchestration on the OCM hub
+cluster. It controls:
+
+- [DRPlacementControl (DRPC)](drpc-crd.md) - DR operations for individual
+  applications
+- [DRPolicy](drpolicy-crd.md) - DR topology and replication configuration
+- DRCluster - Managed cluster registration and S3 configuration
+
+#### Install on Hub Cluster
+
+Configure kubectl to use your OCM hub cluster context:
+
+```bash
+kubectl config use-context <hub-cluster-context>
+```
+
+Install the operator using OLM:
 
 ```bash
 kubectl apply -k github.com/RamenDR/ramen/config/olm-install/hub/?ref=main
 ```
 
-**NOTE**: By default `ramen-hub-operator` creates a deployment for its
-controller in the `ramen-system` namespace. To verify check the health of the
-deployment:
+This creates:
+
+- `ramen-system` namespace
+- Ramen hub operator deployment
+- Required CRDs (DRPlacementControl, DRPolicy, DRCluster)
+- RBAC resources
+
+#### Verify Hub Operator Installation
+
+1. **Check operator deployment:**
+
+   ```bash
+   kubectl get deployments -n ramen-system
+   ```
+
+   Expected output:
+
+   ```
+   NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
+   ramen-hub-operator   1/1     1            1           2m
+   ```
+
+1. **Check operator pod status:**
+
+   ```bash
+   kubectl get pods -n ramen-system
+   ```
+
+   Expected output:
+
+   ```
+   NAME                                  READY   STATUS    RESTARTS   AGE
+   ramen-hub-operator-xxxxxxxxxx-xxxxx   2/2     Running   0          2m
+   ```
+
+1. **Check CRDs are installed:**
+
+   ```bash
+   kubectl get crd | grep ramendr
+   ```
+
+   Expected CRDs:
+
+   ```
+   drplacementcontrols.ramendr.openshift.io
+   drpolicies.ramendr.openshift.io
+   drclusters.ramendr.openshift.io
+   ```
+
+1. **Check operator logs for errors:**
+
+   ```bash
+   kubectl logs -n ramen-system deployment/ramen-hub-operator -c manager
+   ```
+
+### Step 2: Install Ramen DR Cluster Operator
+
+The `ramen-dr-cluster-operator` manages volume replication and workload
+protection on each managed cluster. It controls:
+
+- [VolumeReplicationGroup (VRG)](vrg-crd.md) - PVC replication and application
+  protection
+- Volume replication coordination (VolumeReplication or VolSync)
+- Kube object capture and recovery
+
+**Note:** The hub operator creates VRG resources on managed clusters via
+ManifestWork - you don't create them manually.
+
+#### Install on Each Managed Cluster
+
+Repeat these steps for each managed cluster that will participate in DR.
+
+Configure kubectl to use the managed cluster context:
 
 ```bash
-kubectl get deployments -n ramen-system ramen-hub-operator
+kubectl config use-context <managed-cluster-context>
 ```
 
-## Ramen cluster operator
-
-`ramen-dr-cluster-operator` is the controller for managing the life cycle of
-[VolumeReplicationGroup](vrg-crd.md) Ramen API resources and is installed on
-the **OCM managed clusters**.
-
-**NOTE**: Lifecycle of VolumeReplicationGroup resources are managed by
-[Ramen hub](#ramen-hub-operator) on required OCM managed clusters.
-
-### Install ramen-dr-cluster-operator
-
-To install `ramen-dr-cluster-operator` configure [kubectl](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#context)
-to use the desired OCM managed cluster and execute:
+Install the operator using OLM:
 
 ```bash
 kubectl apply -k github.com/RamenDR/ramen/config/olm-install/dr-cluster/?ref=main
 ```
 
-**NOTE**: By default `ramen-dr-cluster-operator` creates a deployment for its
-controller in the `ramen-system` namespace. To verify check the health of
-the deployment:
+This creates:
+
+- `ramen-system` namespace
+- Ramen DR cluster operator deployment
+- Required CRDs (VolumeReplicationGroup, DRClusterConfig, etc.)
+- RBAC resources
+
+#### Verify DR Cluster Operator Installation
+
+1. **Check operator deployment:**
+
+   ```bash
+   kubectl get deployments -n ramen-system
+   ```
+
+   Expected output:
+
+   ```
+   NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
+   ramen-dr-cluster-operator   1/1     1            1           2m
+   ```
+
+1. **Check operator pod status:**
+
+   ```bash
+   kubectl get pods -n ramen-system
+   ```
+
+   Expected output:
+
+   ```
+   NAME                                         READY   STATUS    RESTARTS   AGE
+   ramen-dr-cluster-operator-xxxxxxxxxx-xxxxx   2/2     Running   0          2m
+   ```
+
+1. **Check CRDs are installed:**
+
+   ```bash
+   kubectl get crd | grep ramendr
+   ```
+
+   Expected CRDs:
+
+   ```
+   volumereplicationgroups.ramendr.openshift.io
+   drclusterconfigs.ramendr.openshift.io
+   maintenancemodes.ramendr.openshift.io
+   ```
+
+1. **Check operator logs:**
+
+   ```bash
+   kubectl logs -n ramen-system deployment/ramen-dr-cluster-operator -c manager
+   ```
+
+### Step 3: Verify Multi-Cluster Installation
+
+Switch back to the hub cluster and verify operators are running on all clusters:
 
 ```bash
-kubectl get deployments -n ramen-system ramen-dr-cluster-operator
+kubectl config use-context <hub-cluster-context>
+
+# Check hub operator
+kubectl get deploy -n ramen-system ramen-hub-operator
+
+# Check managed cluster operators via kubectl with context
+for cluster in dr1 dr2; do
+  echo "Checking cluster: $cluster"
+  kubectl get deploy -n ramen-system ramen-dr-cluster-operator --context $cluster
+done
 ```
+
+## Post-Installation
+
+After installing Ramen operators, you need to configure them for your environment.
+
+### Next Steps
+
+1. **Configure Ramen** - Set up DRPolicy, DRCluster resources, and S3 storage
+
+    - See [configure.md](configure.md) for detailed configuration instructions
+
+1. **Verify storage replication** - Ensure volume replication is working
+
+    - Test VolumeReplication or VolSync on your managed clusters
+
+1. **Protect your first workload** - Deploy an application with DR protection
+
+    - See [usage.md](usage.md) for workload protection methods
+
+### Configuration Prerequisites
+
+Before configuring Ramen, prepare the following information:
+
+- **S3 credentials** for each managed cluster
+
+    - Bucket names
+    - Access key and secret key
+    - S3 endpoint URL
+
+- **Cluster information**
+
+    - Managed cluster names (as registered in OCM)
+    - Storage class names for PVCs
+    - VolumeReplicationClass or VolumeSnapshotClass names
+
+- **Replication schedule** (for async DR)
+
+    - How often to replicate (e.g., "5m", "1h")
+
+## Troubleshooting Installation
+
+### Operator Pod Not Running
+
+**Check pod status:**
+
+```bash
+kubectl describe pod -n ramen-system <pod-name>
+```
+
+**Common issues:**
+
+- Image pull errors - check image registry access
+- OLM not installed - verify `kubectl get csv -n openshift-operators`
+- Resource constraints - check cluster resources
+
+### CRDs Not Created
+
+**Verify OLM created the subscription:**
+
+```bash
+kubectl get subscription -n ramen-system
+kubectl get installplan -n ramen-system
+```
+
+**Check catalog source:**
+
+```bash
+kubectl get catalogsource -n openshift-marketplace
+```
+
+### Operator Logs Show Errors
+
+**View logs:**
+
+```bash
+kubectl logs -n ramen-system deployment/ramen-hub-operator -c manager --tail=100
+```
+
+**Common errors:**
+
+- RBAC permissions - check ClusterRole and ClusterRoleBinding
+- API server connection issues - verify network connectivity
+- Missing dependencies - ensure OCM is properly installed
+
+### Manual Cleanup (if needed)
+
+If you need to uninstall and reinstall:
+
+**Remove hub operator:**
+
+```bash
+kubectl delete -k github.com/RamenDR/ramen/config/olm-install/hub/?ref=main
+```
+
+**Remove DR cluster operator:**
+
+```bash
+kubectl delete -k github.com/RamenDR/ramen/config/olm-install/dr-cluster/?ref=main
+```
+
+**Note:** This will remove the operators but not the CRDs. To remove CRDs:
+
+```bash
+kubectl delete crd drplacementcontrols.ramendr.openshift.io
+kubectl delete crd drpolicies.ramendr.openshift.io
+kubectl delete crd drclusters.ramendr.openshift.io
+kubectl delete crd volumereplicationgroups.ramendr.openshift.io
+```
+
+## Development Installation
+
+For development and testing, see:
+
+- [user-quick-start.md](user-quick-start.md) - Complete test environment setup
+  with drenv
+- [devel-quick-start.md](devel-quick-start.md) - Developer setup for
+  contributing to Ramen

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,8 +1,474 @@
 <!--
 SPDX-FileCopyrightText: The RamenDR authors
-SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: Apache-1.0
 -->
 
-# Sample workload management using Ramen
+# Workload Management Using Ramen
 
-## **Under construction**
+This guide describes how to protect and manage workloads
+using Ramen's disaster recovery capabilities.
+
+## Overview
+
+Ramen provides three methods to protect applications across clusters:
+
+1. **GitOps-based Protection** (Recommended) - For
+    applications deployed via ArgoCD ApplicationSets
+1. **Discovered Applications** - For existing applications
+    deployed via kubectl, Helm, or other methods
+1. **Recipe-based Protection** - For complex stateful
+    applications requiring custom capture/recovery workflows
+
+All methods support the same DR operations:
+
+- **Relocate**: Planned migration to a peer cluster
+- **Failover**: Unplanned recovery due to cluster failure
+- **Failback**: Return to the original cluster after recovery
+
+## Prerequisites
+
+Before protecting workloads with Ramen, ensure:
+
+1. **Ramen is installed** - See [install guide](install.md)
+1. **Ramen is configured** - See [configure guide](configure.md)
+1. **DRPolicy is created** - Defines the DR topology and peer clusters
+1. **Storage replication is configured** - CSI storage with
+    replication support (e.g., Ceph)
+1. **S3 object storage is available** - For storing VRG and PV metadata
+
+## Key Concepts
+
+### DRPolicy
+
+Defines the disaster recovery topology and replication
+configuration between peer clusters.
+
+**Example:**
+
+```yaml
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRPolicy
+metadata:
+  name: dr-policy
+spec:
+  schedulingInterval: "1h" # Replication schedule (async DR)
+  drClusters:
+    - east-cluster
+    - west-cluster
+  replicationClassSelector:
+    matchLabels:
+      class: ramen-replication-class
+  volumeSnapshotClassSelector:
+    matchLabels:
+      class: ramen-snapshot-class
+```
+
+**Key fields:**
+
+- `schedulingInterval`: How often to replicate (e.g., "1h",
+    "30m"). Omit for synchronous DR.
+- `drClusters`: List of peer cluster names participating in DR
+- `replicationClassSelector`: Selects VolumeReplicationClass for async replication
+- `volumeSnapshotClassSelector`: Selects VolumeSnapshotClass for sync replication
+
+### DRPlacementControl (DRPC)
+
+Orchestrates DR operations for a specific application. The DRPC references:
+
+- A DRPolicy (defines where the app can run)
+- A Placement resource (OCM Placement or PlacementRule)
+- PVC selector (which volumes to protect)
+
+**Example:**
+
+```yaml
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRPlacementControl
+metadata:
+  name: my-app-drpc
+  namespace: my-app-namespace
+spec:
+  preferredCluster: east-cluster
+  drPolicyRef:
+    name: dr-policy
+  placementRef:
+    kind: Placement
+    name: my-app-placement
+  pvcSelector:
+    matchLabels:
+      app: my-app
+```
+
+**Key fields:**
+
+- `preferredCluster`: Initial cluster where the application should run
+- `drPolicyRef`: Reference to the DRPolicy
+- `placementRef`: Reference to OCM Placement/PlacementRule
+- `pvcSelector`: Label selector to identify PVCs to protect
+
+### VolumeReplicationGroup (VRG)
+
+Created automatically by the DRPC on managed clusters. The VRG manages:
+
+- Volume replication for PVCs
+- Kube object protection (application resources)
+- Primary/Secondary state coordination
+
+Users typically don't create VRGs directly - they are managed by the DRPC.
+
+## Protection Methods
+
+### Method 1: GitOps-based Protection (Recommended)
+
+Best for applications deployed using ArgoCD ApplicationSets.
+The Git repository serves as the source of truth.
+
+**Workflow:**
+
+1. Deploy your application via ArgoCD ApplicationSet
+1. Create a DRPlacementControl referencing the Placement
+1. Ramen automatically protects PVCs and syncs application state
+
+**Example for ArgoCD ApplicationSet:**
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: my-app
+  namespace: argocd
+spec:
+  generators:
+    - clusterDecisionResource:
+        configMapRef: ocm-placement-generator
+        labelSelector:
+          matchLabels:
+            cluster.open-cluster-management.io/placement: my-app-placement
+  template:
+    metadata:
+      name: my-app
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/example/my-app
+        targetRevision: main
+        path: deploy
+      destination:
+        namespace: my-app
+        name: "{{name}}"
+```
+
+Then create the DRPC:
+
+```yaml
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRPlacementControl
+metadata:
+  name: my-app-drpc
+  namespace: my-app
+spec:
+  preferredCluster: east-cluster
+  drPolicyRef:
+    name: dr-policy
+  placementRef:
+    kind: Placement
+    name: my-app-placement
+  pvcSelector:
+    matchLabels:
+      app: my-app
+```
+
+**Advantages:**
+
+- Declarative and version-controlled
+- Automatic application recreation from Git
+- Industry best practice for cloud-native apps
+
+### Method 2: Discovered Applications
+
+Protects existing applications without GitOps. Ramen
+discovers and captures all Kubernetes resources.
+
+**Workflow:**
+
+1. Deploy your application using any method (kubectl, Helm, etc.)
+1. Label your PVCs for protection
+1. Create a DRPlacementControl with kubeObjectProtection enabled
+
+**Example:**
+
+```yaml
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRPlacementControl
+metadata:
+  name: my-app-drpc
+  namespace: my-app
+spec:
+  preferredCluster: east-cluster
+  drPolicyRef:
+    name: dr-policy
+  placementRef:
+    kind: PlacementRule
+    name: my-app-placement
+  pvcSelector:
+    matchLabels:
+      app: my-app
+  kubeObjectProtection:
+    captureInterval: 5m
+```
+
+**How it works:**
+
+- Ramen captures all resources in the namespace via Velero
+- Resources are stored in S3 object storage
+- During recovery, resources are restored from S3
+
+**Advantages:**
+
+- Works with any deployment method
+- No code or deployment changes required
+- Good for legacy applications
+
+### Method 3: Recipe-based Protection
+
+For complex stateful applications requiring custom workflows (e.g., databases, middleware).
+
+**Use cases:**
+
+- Applications needing quiesce operations before backup
+- Specific resource ordering during capture/recovery
+- Custom pre/post hooks for DR operations
+- Vendor-supplied DR specifications
+
+**Workflow:**
+
+1. Create a Recipe defining capture and recovery workflows
+1. Create a VRG or DRPC referencing the Recipe
+1. Ramen executes the Recipe workflows during DR operations
+
+**Example Recipe:**
+
+```yaml
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: Recipe
+metadata:
+  name: mysql-recipe
+  namespace: mysql-app
+spec:
+  appType: mysql
+  groups:
+    - name: config
+      type: resource
+      includedResourceTypes:
+        - configmap
+        - secret
+    - name: database
+      type: resource
+      includedResourceTypes:
+        - statefulset
+        - service
+    - name: volumes
+      type: volume
+      labelSelector: app=mysql
+  hooks:
+    - name: db-hooks
+      labelSelector: app=mysql
+      ops:
+        - name: pre-backup
+          container: mysql
+          command: ["/scripts/quiesce.sh"]
+          timeout: 300
+        - name: post-restore
+          container: mysql
+          command: ["/scripts/verify.sh"]
+          timeout: 600
+  workflows:
+    - name: capture
+      sequence:
+        - hook: db-hooks/pre-backup
+        - group: config
+        - group: volumes
+        - group: database
+    - name: recover
+      sequence:
+        - group: config
+        - group: volumes
+        - group: database
+        - hook: db-hooks/post-restore
+```
+
+**Reference the Recipe in your VRG:**
+
+```yaml
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: VolumeReplicationGroup
+metadata:
+  name: mysql-vrg
+  namespace: mysql-app
+spec:
+  kubeObjectProtection:
+    recipeRef:
+      name: mysql-recipe
+      captureWorkflowName: capture
+      recoverWorkflowName: recover
+      volumeGroupName: volumes
+```
+
+**For detailed Recipe documentation, see [recipe.md](recipe.md).**
+
+**Advantages:**
+
+- Application-specific protection logic
+- Ensures data consistency
+- Vendor-supported DR workflows
+- Custom hook execution
+
+## Common DR Operations
+
+### Relocate (Planned Migration)
+
+Move an application to a peer cluster during maintenance or optimization.
+
+**Steps:**
+
+1. Update the DRPC action field:
+
+   ```bash
+   kubectl patch drpc my-app-drpc -n my-app --type merge -p '{"spec":{"action":"Relocate","failoverCluster":"west-cluster"}}'
+   ```
+
+1. Monitor the status:
+
+   ```bash
+   kubectl get drpc my-app-drpc -n my-app -o yaml
+   ```
+
+1. Verify application is running on the target cluster:
+
+   ```bash
+   kubectl get pods -n my-app --context west-cluster
+   ```
+
+**What happens:**
+
+- Application is gracefully stopped on the source cluster
+- Final data replication is performed
+- Application starts on the target cluster
+- Replication direction is reversed
+
+### Failover (Unplanned Recovery)
+
+Recover an application on a peer cluster due to source cluster failure.
+
+**Steps:**
+
+1. Trigger failover:
+
+   ```bash
+   kubectl patch drpc my-app-drpc -n my-app --type merge -p '{"spec":{"action":"Failover","failoverCluster":"west-cluster"}}'
+   ```
+
+1. Monitor recovery:
+
+   ```bash
+   kubectl get drpc my-app-drpc -n my-app -w
+   ```
+
+**What happens:**
+
+- Ramen assumes the source cluster is unavailable
+- Latest replicated data is used for recovery
+- Application starts on the target cluster
+- No final sync from source (data loss possible)
+
+### Failback (Return to Original)
+
+Return the application to the original cluster after recovery.
+
+**Steps:**
+
+1. Ensure original cluster is healthy
+1. Trigger failback (same as relocate):
+
+   ```bash
+   kubectl patch drpc my-app-drpc -n my-app --type merge -p '{"spec":{"action":"Relocate","failoverCluster":"east-cluster"}}'
+   ```
+
+## Monitoring DR Protection
+
+### Check DRPC Status
+
+```bash
+kubectl get drpc -A
+kubectl describe drpc my-app-drpc -n my-app
+```
+
+Look for:
+
+- `status.phase`: Current phase (e.g., Deployed, Relocating, FailedOver)
+- `status.conditions`: Detailed condition messages
+- `status.lastGroupSyncTime`: Last successful data sync
+
+### Check VRG Status on Managed Clusters
+
+```bash
+kubectl get vrg -A --context dr1
+kubectl describe vrg my-app-drpc -n my-app --context dr1
+```
+
+Look for:
+
+- `status.state`: Primary or Secondary
+- `status.conditions`: Replication health
+- `status.protectedPVCs`: List of protected volumes
+
+### Check Data Replication
+
+For async replication using VolumeReplication:
+
+```bash
+kubectl get volumereplication -A --context dr1
+```
+
+For sync replication using VolSync:
+
+```bash
+kubectl get replicationsource,replicationdestination -A --context dr1
+```
+
+## Troubleshooting
+
+### Application not failing over
+
+**Check:**
+
+1. DRPC action is set correctly
+1. Target cluster is registered in DRPolicy
+1. VRG on source shows replication is healthy
+1. S3 storage is accessible from target cluster
+
+### Data not replicating
+
+**Check:**
+
+1. VolumeReplicationClass or VolumeSnapshotClass exists
+1. Storage backend supports replication (e.g., Ceph RBD mirroring configured)
+1. VolumeReplication resources are bound
+1. Check VR/VS status for errors
+
+### Kube objects not restoring
+
+**Check:**
+
+1. Velero is installed on all clusters (for discovered apps)
+1. Recipe workflows are valid (for recipe-based apps)
+1. S3 bucket contains backup data
+1. Check VRG events for capture/restore errors
+
+## Next Steps
+
+- **For development testing**: See [user-quick-start.md]
+    user-quick-start.md) to set up a test environment
+- **For Recipe details**: See [recipe.md](recipe.md) for advanced Recipe-based protection
+- **For operational guidance**: See [configure.md](configure.md) for production configuration
+- **For metrics**: See [metrics.md](metrics.md) to monitor Ramen operations

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,82 +1,52 @@
 <!--
 SPDX-FileCopyrightText: The RamenDR authors
-SPDX-License-Identifier: Apache-1.0
+SPDX-License-Identifier: Apache-2.0
 -->
 
 # Workload Management Using Ramen
 
-This guide describes how to protect and manage workloads
-using Ramen's disaster recovery capabilities.
+This guide describes how to protect and manage workloads using Ramen's
+disaster recovery capabilities.
 
 ## Overview
 
-Ramen provides three methods to protect applications across clusters:
+Ramen supports protecting applications across three different deployment types:
 
-1. **GitOps-based Protection** (Recommended) - For
-    applications deployed via ArgoCD ApplicationSets
-1. **Discovered Applications** - For existing applications
-    deployed via kubectl, Helm, or other methods
-1. **Recipe-based Protection** - For complex stateful
-    applications requiring custom capture/recovery workflows
+- GitOps Applications (Recommended) - For applications deployed from Git
+  repositories via ArgoCD ApplicationSets
+- Discovered Applications - For existing applications deployed via kubectl,
+  Helm, or other methods
+- Applications with Recipes - For complex stateful applications requiring
+  custom capture/recovery workflows
 
 All methods support the same DR operations:
 
-- **Relocate**: Planned migration to a peer cluster
-- **Failover**: Unplanned recovery due to cluster failure
-- **Failback**: Return to the original cluster after recovery
+- Relocate: Planned migration to a peer cluster
+- Failover: Unplanned recovery due to cluster failure
 
 ## Prerequisites
 
 Before protecting workloads with Ramen, ensure:
 
-1. **Ramen is installed** - See [install guide](install.md)
-1. **Ramen is configured** - See [configure guide](configure.md)
-1. **DRPolicy is created** - Defines the DR topology and peer clusters
-1. **Storage replication is configured** - CSI storage with
-    replication support (e.g., Ceph)
-1. **S3 object storage is available** - For storing VRG and PV metadata
+- Ramen is installed - See [install guide](install.md)
+- Ramen is configured - See [configure guide](configure.md)
+- DRPolicy is created - Defines the DR topology and peer clusters
+- Storage replication is configured - CSI storage driver with
+  VolumeReplication support (e.g., Ceph CSI)
+- S3 object storage is available - For storing VRG and PV metadata
 
 ## Key Concepts
 
-### DRPolicy
-
-Defines the disaster recovery topology and replication
-configuration between peer clusters.
-
-**Example:**
-
-```yaml
-apiVersion: ramendr.openshift.io/v1alpha1
-kind: DRPolicy
-metadata:
-  name: dr-policy
-spec:
-  schedulingInterval: "1h" # Replication schedule (async DR)
-  drClusters:
-    - east-cluster
-    - west-cluster
-  replicationClassSelector:
-    matchLabels:
-      class: ramen-replication-class
-  volumeSnapshotClassSelector:
-    matchLabels:
-      class: ramen-snapshot-class
-```
-
-**Key fields:**
-
-- `schedulingInterval`: How often to replicate (e.g., "1h",
-    "30m"). Omit for synchronous DR.
-- `drClusters`: List of peer cluster names participating in DR
-- `replicationClassSelector`: Selects VolumeReplicationClass for async replication
-- `volumeSnapshotClassSelector`: Selects VolumeSnapshotClass for sync replication
+**Note:** All Ramen resources use the API group
+`ramendr.openshift.io/v1alpha1`, which is the upstream API group for the
+Ramen project.
 
 ### DRPlacementControl (DRPC)
 
 Orchestrates DR operations for a specific application. The DRPC references:
 
 - A DRPolicy (defines where the app can run)
-- A Placement resource (OCM Placement or PlacementRule)
+- A Placement resource (Open Cluster Management Placement or PlacementRule)
 - PVC selector (which volumes to protect)
 
 **Example:**
@@ -103,80 +73,46 @@ spec:
 
 - `preferredCluster`: Initial cluster where the application should run
 - `drPolicyRef`: Reference to the DRPolicy
-- `placementRef`: Reference to OCM Placement/PlacementRule
+- `placementRef`: Reference to Open Cluster Management Placement/PlacementRule
 - `pvcSelector`: Label selector to identify PVCs to protect
 
 ### VolumeReplicationGroup (VRG)
 
-Created automatically by the DRPC on managed clusters. The VRG manages:
+VRGs are automatically created and managed by the DRPC on managed clusters
+to handle volume replication and application resource protection.
 
-- Volume replication for PVCs
-- Kube object protection (application resources)
-- Primary/Secondary state coordination
+## Application Deployment Types
 
-Users typically don't create VRGs directly - they are managed by the DRPC.
+### GitOps Applications (Recommended)
 
-## Protection Methods
-
-### Method 1: GitOps-based Protection (Recommended)
-
-Best for applications deployed using ArgoCD ApplicationSets.
-The Git repository serves as the source of truth.
+For applications deployed from Git repositories using ArgoCD ApplicationSets.
+The Git repository serves as the source of truth for application configuration
+and deployment.
 
 **Workflow:**
 
-1. Deploy your application via ArgoCD ApplicationSet
-1. Create a DRPlacementControl referencing the Placement
-1. Ramen automatically protects PVCs and syncs application state
+1. Deploy your application via ArgoCD ApplicationSet to your clusters
+1. Create an Open Cluster Management Placement to define cluster selection
+1. Create a DRPlacementControl referencing the Placement and DRPolicy
+1. Ramen automatically protects PVCs and manages application state across clusters
 
-**Example for ArgoCD ApplicationSet:**
+**Sample Applications:**
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: my-app
-  namespace: argocd
-spec:
-  generators:
-    - clusterDecisionResource:
-        configMapRef: ocm-placement-generator
-        labelSelector:
-          matchLabels:
-            cluster.open-cluster-management.io/placement: my-app-placement
-  template:
-    metadata:
-      name: my-app
-    spec:
-      project: default
-      source:
-        repoURL: https://github.com/example/my-app
-        targetRevision: main
-        path: deploy
-      destination:
-        namespace: my-app
-        name: "{{name}}"
-```
+For complete examples of GitOps applications with Ramen DR protection, see
+the [applicationset directory](https://github.com/RamenDR/ocm-ramen-samples/tree/main/applicationset)
+in the ocm-ramen-samples repository.
 
-Then create the DRPC:
+The repository provides sample applications including:
 
-```yaml
-apiVersion: ramendr.openshift.io/v1alpha1
-kind: DRPlacementControl
-metadata:
-  name: my-app-drpc
-  namespace: my-app
-spec:
-  preferredCluster: east-cluster
-  drPolicyRef:
-    name: dr-policy
-  placementRef:
-    kind: Placement
-    name: my-app-placement
-  pvcSelector:
-    matchLabels:
-      app: my-app
-```
+- **Deployment samples**: Busybox deployment examples with different storage configurations
+- **KubeVirt samples**: Virtual machine examples with different storage configurations
+- **Complete DR setup**: DRPlacementControl examples in `dr/` directory
+
+**Example workflow:**
+
+For detailed steps on deploying and enabling DR protection for GitOps
+applications, follow the instructions in the
+[ocm-ramen-samples README](https://github.com/RamenDR/ocm-ramen-samples/blob/main/README.md).
 
 **Advantages:**
 
@@ -184,44 +120,44 @@ spec:
 - Automatic application recreation from Git
 - Industry best practice for cloud-native apps
 
-### Method 2: Discovered Applications
+### Discovered Applications
 
-Protects existing applications without GitOps. Ramen
-discovers and captures all Kubernetes resources.
+Protects existing applications without GitOps. Ramen discovers and captures
+all Kubernetes resources.
 
 **Workflow:**
 
-1. Deploy your application using any method (kubectl, Helm, etc.)
-1. Label your PVCs for protection
+1. Deploy your application using any method (kubectl, Helm, Operator, etc.)
+1. Ensure PVCs have appropriate labels for the DRPC selector
+1. Create an Open Cluster Management Placement to define cluster selection
 1. Create a DRPlacementControl with kubeObjectProtection enabled
 
-**Example:**
+**Sample Applications:**
 
-```yaml
-apiVersion: ramendr.openshift.io/v1alpha1
-kind: DRPlacementControl
-metadata:
-  name: my-app-drpc
-  namespace: my-app
-spec:
-  preferredCluster: east-cluster
-  drPolicyRef:
-    name: dr-policy
-  placementRef:
-    kind: PlacementRule
-    name: my-app-placement
-  pvcSelector:
-    matchLabels:
-      app: my-app
-  kubeObjectProtection:
-    captureInterval: 5m
-```
+For examples of discovered applications that can be deployed and protected,
+see the [workloads directory](https://github.com/RamenDR/ocm-ramen-samples/tree/main/workloads)
+in the ocm-ramen-samples repository.
+
+The workloads directory contains sample applications including:
+
+- **Deployment samples**: Basic containerized applications (busybox)
+- **KubeVirt VMs**: Virtual machine workloads with persistent storage
+    - vm-pvc: PVC based VM
+    - vm-dv: DataVolume based VM
+    - vm-dvt: DataVolumeTemplate based VM
+
+**Example workflow:**
+
+For detailed steps on deploying discovered applications and enabling DR
+protection, follow the instructions in the
+[ocm-ramen-samples README](https://github.com/RamenDR/ocm-ramen-samples/blob/main/README.md).
 
 **How it works:**
 
-- Ramen captures all resources in the namespace via Velero
-- Resources are stored in S3 object storage
-- During recovery, resources are restored from S3
+- Ramen captures Kubernetes resources in the namespace using backup tools
+- Application metadata is stored in S3-compatible object storage
+- During recovery, resources are restored from the backup storage
+- PVCs are recreated and reattached to replicated storage volumes
 
 **Advantages:**
 
@@ -229,7 +165,7 @@ spec:
 - No code or deployment changes required
 - Good for legacy applications
 
-### Method 3: Recipe-based Protection
+### Applications with Recipes
 
 For complex stateful applications requiring custom workflows (e.g., databases, middleware).
 
@@ -243,7 +179,7 @@ For complex stateful applications requiring custom workflows (e.g., databases, m
 **Workflow:**
 
 1. Create a Recipe defining capture and recovery workflows
-1. Create a VRG or DRPC referencing the Recipe
+1. Create a DRPC referencing the Recipe
 1. Ramen executes the Recipe workflows during DR operations
 
 **Example Recipe:**
@@ -297,24 +233,32 @@ spec:
         - hook: db-hooks/post-restore
 ```
 
-**Reference the Recipe in your VRG:**
+**Reference the Recipe in your DRPC:**
 
 ```yaml
 apiVersion: ramendr.openshift.io/v1alpha1
-kind: VolumeReplicationGroup
+kind: DRPlacementControl
 metadata:
-  name: mysql-vrg
+  name: mysql-drpc
   namespace: mysql-app
 spec:
+  preferredCluster: east-cluster
+  drPolicyRef:
+    name: dr-policy
+  placementRef:
+    kind: Placement
+    name: mysql-placement
+  pvcSelector:
+    matchLabels:
+      app: mysql
   kubeObjectProtection:
     recipeRef:
       name: mysql-recipe
       captureWorkflowName: capture
       recoverWorkflowName: recover
-      volumeGroupName: volumes
 ```
 
-**For detailed Recipe documentation, see [recipe.md](recipe.md).**
+For detailed Recipe documentation, see [recipe.md](recipe.md).
 
 **Advantages:**
 
@@ -334,19 +278,19 @@ Move an application to a peer cluster during maintenance or optimization.
 1. Update the DRPC action field:
 
    ```bash
-   kubectl patch drpc my-app-drpc -n my-app --type merge -p '{"spec":{"action":"Relocate","failoverCluster":"west-cluster"}}'
+   kubectl patch drpc my-app-drpc -n my-app-namespace --type merge -p '{"spec":{"action":"Relocate","failoverCluster":"west-cluster"}}'
    ```
 
 1. Monitor the status:
 
    ```bash
-   kubectl get drpc my-app-drpc -n my-app -o yaml
+   kubectl get drpc my-app-drpc -n my-app-namespace -o yaml
    ```
 
 1. Verify application is running on the target cluster:
 
    ```bash
-   kubectl get pods -n my-app --context west-cluster
+   kubectl get pods -n my-app-namespace --context west-cluster
    ```
 
 **What happens:**
@@ -365,13 +309,13 @@ Recover an application on a peer cluster due to source cluster failure.
 1. Trigger failover:
 
    ```bash
-   kubectl patch drpc my-app-drpc -n my-app --type merge -p '{"spec":{"action":"Failover","failoverCluster":"west-cluster"}}'
+   kubectl patch drpc my-app-drpc -n my-app-namespace --type merge -p '{"spec":{"action":"Failover","failoverCluster":"west-cluster"}}'
    ```
 
 1. Monitor recovery:
 
    ```bash
-   kubectl get drpc my-app-drpc -n my-app -w
+   kubectl get drpc my-app-drpc -n my-app-namespace -w
    ```
 
 **What happens:**
@@ -381,26 +325,13 @@ Recover an application on a peer cluster due to source cluster failure.
 - Application starts on the target cluster
 - No final sync from source (data loss possible)
 
-### Failback (Return to Original)
-
-Return the application to the original cluster after recovery.
-
-**Steps:**
-
-1. Ensure original cluster is healthy
-1. Trigger failback (same as relocate):
-
-   ```bash
-   kubectl patch drpc my-app-drpc -n my-app --type merge -p '{"spec":{"action":"Relocate","failoverCluster":"east-cluster"}}'
-   ```
-
 ## Monitoring DR Protection
 
 ### Check DRPC Status
 
 ```bash
 kubectl get drpc -A
-kubectl describe drpc my-app-drpc -n my-app
+kubectl describe drpc my-app-drpc -n my-app-namespace
 ```
 
 Look for:
@@ -409,66 +340,10 @@ Look for:
 - `status.conditions`: Detailed condition messages
 - `status.lastGroupSyncTime`: Last successful data sync
 
-### Check VRG Status on Managed Clusters
-
-```bash
-kubectl get vrg -A --context dr1
-kubectl describe vrg my-app-drpc -n my-app --context dr1
-```
-
-Look for:
-
-- `status.state`: Primary or Secondary
-- `status.conditions`: Replication health
-- `status.protectedPVCs`: List of protected volumes
-
-### Check Data Replication
-
-For async replication using VolumeReplication:
-
-```bash
-kubectl get volumereplication -A --context dr1
-```
-
-For sync replication using VolSync:
-
-```bash
-kubectl get replicationsource,replicationdestination -A --context dr1
-```
-
-## Troubleshooting
-
-### Application not failing over
-
-**Check:**
-
-1. DRPC action is set correctly
-1. Target cluster is registered in DRPolicy
-1. VRG on source shows replication is healthy
-1. S3 storage is accessible from target cluster
-
-### Data not replicating
-
-**Check:**
-
-1. VolumeReplicationClass or VolumeSnapshotClass exists
-1. Storage backend supports replication (e.g., Ceph RBD mirroring configured)
-1. VolumeReplication resources are bound
-1. Check VR/VS status for errors
-
-### Kube objects not restoring
-
-**Check:**
-
-1. Velero is installed on all clusters (for discovered apps)
-1. Recipe workflows are valid (for recipe-based apps)
-1. S3 bucket contains backup data
-1. Check VRG events for capture/restore errors
-
 ## Next Steps
 
-- **For development testing**: See [user-quick-start.md]
-    user-quick-start.md) to set up a test environment
-- **For Recipe details**: See [recipe.md](recipe.md) for advanced Recipe-based protection
-- **For operational guidance**: See [configure.md](configure.md) for production configuration
-- **For metrics**: See [metrics.md](metrics.md) to monitor Ramen operations
+- For development testing: See [user-quick-start.md](user-quick-start.md)
+  to set up a test environment
+- For Recipe details: See [recipe.md](recipe.md) for advanced Recipe-based protection
+- For operational guidance: See [configure.md](configure.md) for production configuration
+- For metrics: See [metrics.md](metrics.md) to monitor Ramen operations

--- a/test/scripts/pull-events-stats
+++ b/test/scripts/pull-events-stats
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+r"""
+Analyze image pull events from kubectl-gather output.
+
+This is useful for understanding image pull performance and working on
+caching images.
+
+Usage:
+
+    pull-events-stats gather.rdr/ [options]
+
+Example - slowest pulls across all clusters:
+
+    $ scripts/pull-events-stats test/gather.rdr \
+        --top 5 \
+        --sort pull-time \
+        --output cluster,image,size,pull-time,bandwidth
+    Cluster | Image                           |    Size | Pull Time | Bandwidth
+    ---------------------------------------------------------------------------
+    dr1     | quay.io/cephcsi/cephcsi:v3.15.0 | 972 MiB |   58.384s |  17 MiB/s
+    dr1     | quay.io/cephcsi/cephcsi:v3.15.0 | 972 MiB |   58.371s |  17 MiB/s
+    dr2     | quay.io/cephcsi/cephcsi:v3.15.0 | 972 MiB |   45.882s |  21 MiB/s
+    dr2     | quay.io/cephcsi/cephcsi:v3.15.0 | 972 MiB |   45.502s |  21 MiB/s
+    dr1     | quay.io/cephcsi/cephcsi:v3.15.0 | 972 MiB |   39.015s |  25 MiB/s
+
+Example - which pods pulled a specific image?
+
+    $ scripts/pull-events-stats test/gather.rdr \
+        --image quay.io/cephcsi/cephcsi:v3.15.0 \
+        --cluster dr1 \
+        --sort pull-time \
+        --output namespace,pod,pull-time,bandwidth
+    Namespace | Pod                                           | Pull Time | Bandwidth
+    ---------------------------------------------------------------------------------
+    rook-ceph | csi-cephfsplugin-hg22z                        |   27.765s |  33 MiB/s
+    rook-ceph | csi-rbdplugin-9ptzn                           |   27.703s |  33 MiB/s
+    rook-ceph | csi-rbdplugin-provisioner-7dbbbd8dd4-hnjgd    |   21.120s |  44 MiB/s
+    rook-ceph | csi-cephfsplugin-provisioner-795c476bdb-8w55q |   21.061s |  44 MiB/s
+
+More examples:
+
+    # Show all pulls in chronological order
+    pull-events-stats gather.rdr/ --top 0
+
+    # Show pulls grouped by image, then by time
+    pull-events-stats gather.rdr/ --sort=image,timestamp
+
+    # Show pulls grouped by cluster, then by time
+    pull-events-stats gather.rdr/ --sort=cluster,timestamp
+
+    # Show top 20 slowest pulls across all clusters
+    pull-events-stats gather.rdr/ --sort=pull-time
+
+    # Filter by cluster
+    pull-events-stats gather.rdr/ --cluster=dr1
+
+    # Filter by image name pattern
+    pull-events-stats gather.rdr/ --image=ceph
+
+    # Output as CSV for further analysis
+    pull-events-stats gather.rdr/ --format=csv
+"""
+
+import argparse
+import csv
+import pickle
+import re
+import sys
+from collections import namedtuple
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+# Immutable event data - stored in cache.
+PullEvent = namedtuple(
+    "PullEvent",
+    [
+        "cluster",
+        "namespace",
+        "pod",
+        "image",
+        "pull_time_ms",
+        "total_time_ms",
+        "size_bytes",
+        "timestamp",
+    ],
+)
+
+CACHE_FILE = ".pull-events.pickle"
+
+# Pattern to parse the pull event note.
+# Example: 'Successfully pulled image "quay.io/foo:v1" in 10.745s (55.002s including waiting). Image size: 86212232 bytes.'
+PULL_PATTERN = re.compile(
+    r'Successfully pulled image "([^"]+)" in ([0-9.]+(?:ms|s)) '
+    r"\(([0-9.]+(?:ms|s)) including waiting\)\. "
+    r"Image size: (\d+) bytes\."
+)
+
+# Sort key definitions: name -> sort function.
+# Negative values for descending order by default.
+SORT_KEYS = {
+    "timestamp": lambda e: e.timestamp,
+    "pull-time": lambda e: -e.pull_time_ms,
+    "total-time": lambda e: -e.total_time_ms,
+    "size": lambda e: -e.size_bytes,
+    "bandwidth": lambda e: -bandwidth_mbs(e),
+    "image": lambda e: e.image,
+    "cluster": lambda e: e.cluster,
+    "namespace": lambda e: e.namespace,
+}
+
+# Column definitions: name -> (header, formatter, alignment).
+# Alignment: "<" left, ">" right.
+COLUMNS = {
+    "time": ("Time", lambda e: format_timestamp(e.timestamp), "<"),
+    "cluster": ("Cluster", lambda e: e.cluster, "<"),
+    "namespace": ("Namespace", lambda e: e.namespace, "<"),
+    "pod": ("Pod", lambda e: e.pod, "<"),
+    "image": ("Image", lambda e: e.image, "<"),
+    "size": ("Size", lambda e: format_size(e.size_bytes), ">"),
+    "pull-time": ("Pull Time", lambda e: format_time(e.pull_time_ms), ">"),
+    "total-time": ("Total Time", lambda e: format_time(e.total_time_ms), ">"),
+    "bandwidth": ("Bandwidth", lambda e: format_bandwidth(bandwidth_mbs(e)), ">"),
+}
+
+DEFAULT_COLUMNS = "time,cluster,namespace,pod,image,size,pull-time,total-time,bandwidth"
+
+
+def main():
+    args = parse_args()
+    events = find_pull_events(args.gather_dir)
+
+    if args.cluster:
+        events = [e for e in events if e.cluster == args.cluster]
+    if args.namespace:
+        events = [e for e in events if e.namespace == args.namespace]
+    if args.image:
+        events = [e for e in events if args.image in e.image]
+
+    events = sort_events(events, args.sort, args.reverse)
+
+    if args.top > 0:
+        events = events[: args.top]
+
+    if args.format == "table":
+        print_table(events, args.output)
+    elif args.format == "csv":
+        print_csv(events, args.output)
+    elif args.format == "markdown":
+        print_markdown(events, args.output)
+
+
+# Parsing arguments.
+
+
+def parse_args():
+    """Parse and validate command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Analyze image pull events from kubectl-gather output.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "gather_dir",
+        type=Path,
+        help="Path to gather.rdr directory",
+    )
+    parser.add_argument(
+        "--sort",
+        type=sortkeys,
+        default=sortkeys("timestamp"),
+        metavar="KEYS",
+        help="Sort by comma-separated keys: timestamp, pull-time, total-time, "
+        "size, bandwidth, image, cluster, namespace (default: timestamp)",
+    )
+    parser.add_argument(
+        "-r",
+        "--reverse",
+        action="store_true",
+        help="Reverse sort order",
+    )
+    parser.add_argument(
+        "--cluster",
+        help="Filter by cluster name",
+    )
+    parser.add_argument(
+        "--namespace",
+        help="Filter by namespace",
+    )
+    parser.add_argument(
+        "--image",
+        help="Filter by image name (substring match)",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=20,
+        metavar="N",
+        help="Show only top N results (default: 20, use 0 for all)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "csv", "markdown"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=columns,
+        default=columns(DEFAULT_COLUMNS),
+        metavar="COLS",
+        help=f"Comma-separated columns to display: {','.join(COLUMNS)} (default: {DEFAULT_COLUMNS})",
+    )
+
+    args = parser.parse_args()
+
+    if not args.gather_dir.exists():
+        parser.error(f"{args.gather_dir} does not exist")
+
+    return args
+
+
+def sortkeys(s):
+    """Parse and validate comma-separated sort keys."""
+    keys = [k.strip() for k in s.split(",")]
+    for key in keys:
+        if key not in SORT_KEYS:
+            raise argparse.ArgumentTypeError(
+                f"Unknown sort key '{key}'. Available: {', '.join(SORT_KEYS)}"
+            )
+    return keys
+
+
+def columns(s):
+    """Parse and validate comma-separated column names."""
+    cols = [c.strip() for c in s.split(",")]
+    for col in cols:
+        if col not in COLUMNS:
+            raise argparse.ArgumentTypeError(
+                f"Unknown column '{col}'. Available: {', '.join(COLUMNS)}"
+            )
+    return cols
+
+
+# Reading gathered events.
+
+
+def find_pull_events(gather_dir: Path) -> list[PullEvent]:
+    """Find all pull events in the gather directory."""
+    # Try loading from cache first.
+    events = load_cache(gather_dir)
+    if events is not None:
+        return events
+
+    # Parse YAML files and build cache.
+    events = []
+
+    # Pattern: {cluster}/namespaces/{namespace}/events.k8s.io/events/{event}.yaml
+    pattern = "*/namespaces/*/events.k8s.io/events/*.yaml"
+
+    for event_file in gather_dir.glob(pattern):
+        # Extract cluster and namespace from path.
+        # Path: gather_dir / cluster / namespaces / namespace / events.k8s.io / events / file.yaml
+        parts = event_file.relative_to(gather_dir).parts
+        cluster = parts[0]
+        namespace = parts[2]
+
+        event = parse_event_file(event_file, cluster, namespace)
+        if event:
+            events.append(event)
+
+    save_cache(gather_dir, events)
+    return events
+
+
+# Sorting.
+
+
+def sort_events(
+    events: list[PullEvent], keys: list[str], reverse: bool
+) -> list[PullEvent]:
+    """Sort events by the specified keys."""
+
+    def sort_key(e):
+        return tuple(SORT_KEYS[k](e) for k in keys)
+
+    return sorted(events, key=sort_key, reverse=reverse)
+
+
+# Printing output.
+
+
+def print_table(events: list[PullEvent], columns: list[str]) -> None:
+    """Print events as a formatted table."""
+    if not events:
+        print("No pull events found.")
+        return
+
+    # Get column info.
+    headers = [COLUMNS[col][0] for col in columns]
+    formatters = [COLUMNS[col][1] for col in columns]
+    aligns = [COLUMNS[col][2] for col in columns]
+
+    # Build rows.
+    rows = []
+    for e in events:
+        rows.append([fmt(e) for fmt in formatters])
+
+    # Calculate column widths.
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    # Print header.
+    header_line = " | ".join(
+        f"{h:{aligns[i]}{widths[i]}}" for i, h in enumerate(headers)
+    )
+    print(header_line)
+    print("-" * len(header_line))
+
+    # Print rows.
+    for row in rows:
+        print(
+            " | ".join(f"{cell:{aligns[i]}{widths[i]}}" for i, cell in enumerate(row))
+        )
+
+
+def print_csv(events: list[PullEvent], columns: list[str]) -> None:
+    """Print events as CSV."""
+    # Get headers and formatters for selected columns.
+    headers = [COLUMNS[col][0] for col in columns]
+    formatters = [COLUMNS[col][1] for col in columns]
+
+    writer = csv.writer(sys.stdout)
+    writer.writerow(headers)
+
+    for e in events:
+        writer.writerow([fmt(e) for fmt in formatters])
+
+
+def print_markdown(events: list[PullEvent], columns: list[str]) -> None:
+    """Print events as markdown table."""
+    if not events:
+        print("No pull events found.")
+        return
+
+    # Get headers and formatters for selected columns.
+    headers = [COLUMNS[col][0] for col in columns]
+    formatters = [COLUMNS[col][1] for col in columns]
+
+    # Print header.
+    print("| " + " | ".join(headers) + " |")
+    print("|" + "|".join("---" for _ in headers) + "|")
+
+    # Print rows.
+    for e in events:
+        cells = [fmt(e) for fmt in formatters]
+        print("| " + " | ".join(cells) + " |")
+
+
+# Managing cached events.
+
+
+def load_cache(gather_dir: Path) -> list[PullEvent] | None:
+    """Load events from cache if exists."""
+    cache_path = gather_dir / CACHE_FILE
+    if not cache_path.exists():
+        return None
+
+    with open(cache_path, "rb") as f:
+        return pickle.load(f)
+
+
+def save_cache(gather_dir: Path, events: list[PullEvent]) -> None:
+    """Save events to cache."""
+    with open(gather_dir / CACHE_FILE, "wb") as f:
+        pickle.dump(events, f)
+
+
+# Parsing events.
+
+
+def parse_event_file(path: Path, cluster: str, namespace: str) -> PullEvent | None:
+    """Parse a single event file and return PullEvent if it's a pull event."""
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+    except Exception as e:
+        print(f"Warning: Failed to parse {path}: {e}", file=sys.stderr)
+        return None
+
+    # Check if this is a Pulled event.
+    if data.get("reason") != "Pulled":
+        return None
+
+    note = data.get("note", "")
+    parsed = parse_pull_note(note)
+    if not parsed:
+        return None
+
+    image, pull_time_ms, total_time_ms, size_bytes = parsed
+
+    # Get pod name from regarding field.
+    regarding = data.get("regarding", {})
+    pod = regarding.get("name", "unknown")
+
+    # Get timestamp from metadata.
+    metadata = data.get("metadata", {})
+    ts_str = metadata.get("creationTimestamp", "")
+    try:
+        timestamp = parse_timestamp(ts_str)
+    except Exception:
+        timestamp = datetime.min
+
+    return PullEvent(
+        cluster=cluster,
+        namespace=namespace,
+        pod=pod,
+        image=image,
+        pull_time_ms=pull_time_ms,
+        total_time_ms=total_time_ms,
+        size_bytes=size_bytes,
+        timestamp=timestamp,
+    )
+
+
+def parse_pull_note(note: str) -> tuple[str, int, int, int] | None:
+    """
+    Parse pull event note and return (image, pull_time_ms, total_time_ms, size_bytes).
+    Returns None if the note doesn't match the expected pattern.
+    """
+    match = PULL_PATTERN.search(note)
+    if not match:
+        return None
+
+    image = match.group(1)
+    pull_time_ms = parse_time_ms(match.group(2))
+    total_time_ms = parse_time_ms(match.group(3))
+    size_bytes = int(match.group(4))
+
+    return image, pull_time_ms, total_time_ms, size_bytes
+
+
+def parse_timestamp(ts_str: str) -> datetime:
+    """Parse Kubernetes timestamp string to datetime."""
+    # Format: 2026-01-31T02:17:20Z
+    return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+
+
+def parse_time_ms(time_str: str) -> int:
+    """Parse time string to milliseconds."""
+    if time_str.endswith("ms"):
+        return int(float(time_str[:-2]))
+    elif time_str.endswith("s"):
+        return int(float(time_str[:-1]) * 1000)
+    else:
+        raise ValueError(f"Unknown time format: {time_str}")
+
+
+# Formatting values.
+
+
+def bandwidth_mbs(event):
+    """Bandwidth in MiB/s based on pull time."""
+    if event.pull_time_ms == 0:
+        return 0
+    return event.size_bytes / 1024 / 1024 / (event.pull_time_ms / 1000)
+
+
+def format_time(ms: int) -> str:
+    """Format milliseconds as seconds."""
+    return f"{ms / 1000:.3f}s"
+
+
+def format_size(bytes_: int) -> str:
+    """Format bytes as human-readable size."""
+    mb = bytes_ / 1024 / 1024
+    return f"{mb:.0f} MiB"
+
+
+def format_bandwidth(mbs: float) -> str:
+    """Format bandwidth as MiB/s."""
+    return f"{mbs:.0f} MiB/s"
+
+
+def format_timestamp(ts: datetime) -> str:
+    """Format timestamp for display."""
+    return ts.strftime("%H:%M:%S")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/scripts/pull-events-stats
+++ b/test/scripts/pull-events-stats
@@ -40,6 +40,14 @@ Example - which pods pulled a specific image?
     rook-ceph | csi-rbdplugin-provisioner-7dbbbd8dd4-hnjgd    |   21.120s |  44 MiB/s
     rook-ceph | csi-cephfsplugin-provisioner-795c476bdb-8w55q |   21.061s |  44 MiB/s
 
+Example - summary statistics:
+
+    $ scripts/pull-events-stats test/gather.rdr --summary
+    Pull events:        117
+    Total size:         14774 MiB
+    Total pull time:    1206.1s
+    Weighted bandwidth: 12.2 MiB/s
+
 More examples:
 
     # Show all pulls in chronological order
@@ -143,6 +151,11 @@ def main():
 
     events = sort_events(events, args.sort, args.reverse)
 
+    if args.summary:
+        # Summary uses all events, ignoring --top limit.
+        print_summary(events, args.format)
+        return
+
     if args.top > 0:
         events = events[: args.top]
 
@@ -207,6 +220,11 @@ def parse_args():
         choices=["table", "csv", "markdown"],
         default="table",
         help="Output format (default: table)",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Show summary statistics (pull events, total size, total time, weighted bandwidth)",
     )
     parser.add_argument(
         "-o",
@@ -362,6 +380,51 @@ def print_markdown(events: list[PullEvent], columns: list[str]) -> None:
     for e in events:
         cells = [fmt(e) for fmt in formatters]
         print("| " + " | ".join(cells) + " |")
+
+
+def print_summary(events: list[PullEvent], format: str) -> None:
+    """Print summary statistics for pull events."""
+    if not events:
+        print("No pull events found.")
+        return
+
+    # Calculate summary statistics.
+    pull_count = len(events)
+    total_size_bytes = sum(e.size_bytes for e in events)
+    total_pull_time_ms = sum(e.pull_time_ms for e in events)
+
+    # Weighted bandwidth: total size / total time.
+    if total_pull_time_ms > 0:
+        weighted_bandwidth_mbs = (
+            total_size_bytes / 1024 / 1024 / (total_pull_time_ms / 1000)
+        )
+    else:
+        weighted_bandwidth_mbs = 0
+
+    # Format values.
+    total_size_mib = total_size_bytes / 1024 / 1024
+    total_pull_time_s = total_pull_time_ms / 1000
+
+    if format == "csv":
+        writer = csv.writer(sys.stdout)
+        writer.writerow(["Metric", "Value"])
+        writer.writerow(["Pull events", pull_count])
+        writer.writerow(["Total size (MiB)", f"{total_size_mib:.0f}"])
+        writer.writerow(["Total pull time (s)", f"{total_pull_time_s:.1f}"])
+        writer.writerow(["Weighted bandwidth (MiB/s)", f"{weighted_bandwidth_mbs:.1f}"])
+    elif format == "markdown":
+        print("| Metric | Value |")
+        print("|--------|-------|")
+        print(f"| Pull events | {pull_count} |")
+        print(f"| Total size | {total_size_mib:.0f} MiB |")
+        print(f"| Total pull time | {total_pull_time_s:.1f}s |")
+        print(f"| Weighted bandwidth | {weighted_bandwidth_mbs:.1f} MiB/s |")
+    else:
+        # Table format.
+        print(f"Pull events:        {pull_count}")
+        print(f"Total size:         {total_size_mib:.0f} MiB")
+        print(f"Total pull time:    {total_pull_time_s:.1f}s")
+        print(f"Weighted bandwidth: {weighted_bandwidth_mbs:.1f} MiB/s")
 
 
 # Managing cached events.

--- a/test/scripts/pull-events-stats
+++ b/test/scripts/pull-events-stats
@@ -10,7 +10,7 @@ caching images.
 
 Usage:
 
-    pull-events-stats gather.rdr/ [options]
+    pull-events-stats [options] gather.rdr/ [gather2.rdr/ ...]
 
 Example - slowest pulls across all clusters:
 
@@ -45,7 +45,15 @@ Example - summary statistics:
     $ scripts/pull-events-stats test/gather.rdr --summary
     Pull events:        117
     Total size:         14774 MiB
-    Total pull time:    1206.1s
+    Total pull time:    1206.1 s
+    Weighted bandwidth: 12.2 MiB/s
+
+Example - aggregate multiple runs:
+
+    $ scripts/pull-events-stats --summary out/*.gather
+    Pull events:        1170
+    Total size:         147740 MiB
+    Total pull time:    12061.0 s
     Weighted bandwidth: 12.2 MiB/s
 
 More examples:
@@ -140,7 +148,11 @@ DEFAULT_COLUMNS = "time,cluster,namespace,pod,image,size,pull-time,total-time,ba
 
 def main():
     args = parse_args()
-    events = find_pull_events(args.gather_dir)
+
+    # Collect events from all gather directories.
+    events = []
+    for gather_dir in args.gather_dirs:
+        events.extend(find_pull_events(gather_dir))
 
     if args.cluster:
         events = [e for e in events if e.cluster == args.cluster]
@@ -178,9 +190,11 @@ def parse_args():
         epilog=__doc__,
     )
     parser.add_argument(
-        "gather_dir",
+        "gather_dirs",
         type=Path,
-        help="Path to gather.rdr directory",
+        nargs="+",
+        metavar="GATHER_DIR",
+        help="Path to gather.rdr directory (one or more)",
     )
     parser.add_argument(
         "--sort",
@@ -237,8 +251,9 @@ def parse_args():
 
     args = parser.parse_args()
 
-    if not args.gather_dir.exists():
-        parser.error(f"{args.gather_dir} does not exist")
+    for gather_dir in args.gather_dirs:
+        if not gather_dir.exists():
+            parser.error(f"{gather_dir} does not exist")
 
     return args
 
@@ -417,13 +432,13 @@ def print_summary(events: list[PullEvent], format: str) -> None:
         print("|--------|-------|")
         print(f"| Pull events | {pull_count} |")
         print(f"| Total size | {total_size_mib:.0f} MiB |")
-        print(f"| Total pull time | {total_pull_time_s:.1f}s |")
+        print(f"| Total pull time | {total_pull_time_s:.1f} s |")
         print(f"| Weighted bandwidth | {weighted_bandwidth_mbs:.1f} MiB/s |")
     else:
         # Table format.
         print(f"Pull events:        {pull_count}")
         print(f"Total size:         {total_size_mib:.0f} MiB")
-        print(f"Total pull time:    {total_pull_time_s:.1f}s")
+        print(f"Total pull time:    {total_pull_time_s:.1f} s")
         print(f"Weighted bandwidth: {weighted_bandwidth_mbs:.1f} MiB/s")
 
 
@@ -538,7 +553,7 @@ def bandwidth_mbs(event):
 
 def format_time(ms: int) -> str:
     """Format milliseconds as seconds."""
-    return f"{ms / 1000:.3f}s"
+    return f"{ms / 1000:.3f} s"
 
 
 def format_size(bytes_: int) -> str:

--- a/test/scripts/pull-events-stats
+++ b/test/scripts/pull-events-stats
@@ -56,6 +56,17 @@ Example - aggregate multiple runs:
     Total pull time:    12061.0 s
     Weighted bandwidth: 12.2 MiB/s
 
+Example - compare before/after runs:
+
+    $ scripts/pull-events-stats --compare out.before/*.gather out.after/*.gather
+    Metric               | out.before         | out.after          |   Change
+    -------------------------------------------------------------------------
+    Runs                 |                 10 |                 10 |        -
+    Pull events          |               1197 |               1266 |    1.06x
+    Total size           |         154312 MiB |         187094 MiB |    1.21x
+    Total pull time      |           11590.1s |            5272.4s |    0.45x
+    Weighted bandwidth   |         13.3 MiB/s |         35.5 MiB/s |    2.67x
+
 More examples:
 
     # Show all pulls in chronological order
@@ -149,6 +160,10 @@ DEFAULT_COLUMNS = "time,cluster,namespace,pod,image,size,pull-time,total-time,ba
 def main():
     args = parse_args()
 
+    if args.compare:
+        print_comparison(args.gather_dirs, args.format)
+        return
+
     # Collect events from all gather directories.
     events = []
     for gather_dir in args.gather_dirs:
@@ -239,6 +254,11 @@ def parse_args():
         "--summary",
         action="store_true",
         help="Show summary statistics (pull events, total size, total time, weighted bandwidth)",
+    )
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="Compare summary statistics grouped by parent directory",
     )
     parser.add_argument(
         "-o",
@@ -440,6 +460,97 @@ def print_summary(events: list[PullEvent], format: str) -> None:
         print(f"Total size:         {total_size_mib:.0f} MiB")
         print(f"Total pull time:    {total_pull_time_s:.1f} s")
         print(f"Weighted bandwidth: {weighted_bandwidth_mbs:.1f} MiB/s")
+
+
+def print_comparison(gather_dirs: list[Path], format: str) -> None:
+    """Print comparison of summary statistics grouped by first path component."""
+    # Group directories by first path component.
+    groups = {}
+    for gather_dir in gather_dirs:
+        # Use first component of the path as the group name.
+        group = gather_dir.parts[0]
+        if group not in groups:
+            groups[group] = []
+        groups[group].append(gather_dir)
+
+    if len(groups) != 2:
+        print("Error: --compare requires exactly 2 groups of directories.")
+        sys.exit(1)
+
+    # Compute stats for each group.
+    stats = []
+    for group_name, dirs in sorted(groups.items()):
+        events = []
+        for gather_dir in dirs:
+            events.extend(find_pull_events(gather_dir))
+
+        pull_count = len(events)
+        total_size_bytes = sum(e.size_bytes for e in events)
+        total_pull_time_ms = sum(e.pull_time_ms for e in events)
+
+        if total_pull_time_ms > 0:
+            weighted_bandwidth_mbs = (
+                total_size_bytes / 1024 / 1024 / (total_pull_time_ms / 1000)
+            )
+        else:
+            weighted_bandwidth_mbs = 0
+
+        stats.append({
+            "name": group_name,
+            "runs": len(dirs),
+            "pull_count": pull_count,
+            "total_size_mib": total_size_bytes / 1024 / 1024,
+            "total_pull_time_s": total_pull_time_ms / 1000,
+            "weighted_bandwidth_mbs": weighted_bandwidth_mbs,
+        })
+
+    # Print comparison table with metrics as rows and groups as columns.
+    s1, s2 = stats[0], stats[1]
+
+    def ratio(old, new):
+        if old == 0:
+            return 1.0
+        return new / old
+
+    changes = {
+        "runs": "-",
+        "pull_count": f"{ratio(s1['pull_count'], s2['pull_count']):.2f}x",
+        "total_size_mib": f"{ratio(s1['total_size_mib'], s2['total_size_mib']):.2f}x",
+        "total_pull_time_s": f"{ratio(s1['total_pull_time_s'], s2['total_pull_time_s']):.2f}x",
+        "weighted_bandwidth_mbs": f"{ratio(s1['weighted_bandwidth_mbs'], s2['weighted_bandwidth_mbs']):.2f}x",
+    }
+
+    # Define rows: (label, key, format_func)
+    rows = [
+        ("Runs", "runs", lambda v: f"{v}"),
+        ("Pull events", "pull_count", lambda v: f"{v}"),
+        ("Total size", "total_size_mib", lambda v: f"{v:.0f} MiB"),
+        ("Total pull time", "total_pull_time_s", lambda v: f"{v:.1f} s"),
+        ("Weighted bandwidth", "weighted_bandwidth_mbs", lambda v: f"{v:.1f} MiB/s"),
+    ]
+
+    if format == "csv":
+        writer = csv.writer(sys.stdout)
+        writer.writerow(["Metric", s1["name"], s2["name"], "Change"])
+        for label, key, fmt in rows:
+            writer.writerow([label, fmt(s1[key]), fmt(s2[key]), changes[key]])
+    elif format == "markdown":
+        print(f"| Metric | {s1['name']} | {s2['name']} | Change |")
+        print("|--------|" + "-" * (len(s1['name']) + 2) + "|" + "-" * (len(s2['name']) + 2) + "|--------|")
+        for label, key, fmt in rows:
+            print(f"| {label} | {fmt(s1[key])} | {fmt(s2[key])} | {changes[key]} |")
+    else:
+        # Table format.
+        col1_width = max(len(s1["name"]), 10)
+        col2_width = max(len(s2["name"]), 10)
+
+        header = f"{'Metric':<20} | {s1['name']:>{col1_width}} | {s2['name']:>{col2_width}} | {'Change':>8}"
+        print(header)
+        print("-" * len(header))
+        for label, key, fmt in rows:
+            v1 = fmt(s1[key])
+            v2 = fmt(s2[key])
+            print(f"{label:<20} | {v1:>{col1_width}} | {v2:>{col2_width}} | {changes[key]:>8}")
 
 
 # Managing cached events.

--- a/test/stress-test/run
+++ b/test/stress-test/run
@@ -125,14 +125,13 @@ def run(name, args):
     elapsed = time.monotonic() - start
     passed = cp.returncode == 0
 
-    if not passed:
-        drenv(
-            "gather",
-            args.envfile,
-            log,
-            name_prefix=args.name_prefix,
-            directory=os.path.join(args.outdir, name + ".gather"),
-        )
+    drenv(
+        "gather",
+        args.envfile,
+        log,
+        name_prefix=args.name_prefix,
+        directory=os.path.join(args.outdir, name + ".gather"),
+    )
 
     if passed or not args.exit_first:
         drenv(


### PR DESCRIPTION
## Summary

Add `pull-events-stats` script for analyzing image pull performance from kubectl-gather output.

Features:
- Analyze pull events showing cluster, namespace, pod, image, size, pull time, and bandwidth
- Filter by cluster, namespace, or image name
- Sort by any field (timestamp, pull-time, size, bandwidth, etc.)
- `--summary` flag for aggregate statistics (pull count, total size, total time, weighted bandwidth)
- `--compare` flag for before/after analysis with automatic grouping by directory
- Support multiple gather directories for aggregating results across runs
- Output formats: table, CSV, markdown

## Example usage

```bash
# Show top 5 slowest pulls
pull-events-stats gather.rdr/ --top 5 --sort pull-time

# Summary statistics for multiple runs
pull-events-stats --summary out/*.gather

# Compare before/after performance
pull-events-stats --compare out.before/*.gather out.after/*.gather
Metric               | out.before         | out.after          |   Change
-------------------------------------------------------------------------
Runs                 |                 10 |                 10 |        -
Pull events          |               1197 |               1266 |    1.06x
Total size           |         154312 MiB |         187094 MiB |    1.21x
Total pull time      |          11590.1 s |           5272.4 s |    0.45x
Weighted bandwidth   |         13.3 MiB/s |         35.5 MiB/s |    2.67x
```

## Test plan

- [ ] Run `pull-events-stats` on existing gather output
- [ ] Test `--summary` with single and multiple directories
- [ ] Test `--compare` with two groups of gather directories
- [ ] Verify CSV and markdown output formats