### PR TITLE
e2e: Run if PR has label e2e-approved

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   e2e-rdr:
     runs-on: [self-hosted, e2e-rdr]
-    if: github.repository == 'RamenDR/ramen' && github.event.pull_request.author_association == 'MEMBER'
+    if: contains(github.event.pull_request.labels.*.name, 'e2e-approved')
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,6 +9,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+  # Allow manual run.
+  # (Actions -> E2E -> Run workflow)
+  workflow_dispatch:
+
 env:
   # Limit number of drenv workers.
   MAX_WORKERS: 4


### PR DESCRIPTION
Replace the github repo and member check with label check. This allows maintainers to approve PR from any author to run the e2e workflow.